### PR TITLE
fixes assets url to path logic for non wp install in non default loca…

### DIFF
--- a/includes/kc.functions.php
+++ b/includes/kc.functions.php
@@ -760,8 +760,8 @@ function kc_attach_url($url = '') {
 
 	$test_exist = str_replace(
 		array(KC_SITE, '/', '\\'),
-		array(untrailingslashit(ABSPATH), KDS, KDS),
-		$url
+        array(untrailingslashit(dirname(WP_CONTENT_DIR)), KDS, KDS),
+        $url
 	);
 
 	if (count($xmls) === 0) {


### PR DESCRIPTION
…tions

depending on the ABSPATH constant works wordpress is installed in the same location as the pw-content directory. When it's not (see https://codex.wordpress.org/Giving_WordPress_Its_Own_Directory) you're better of using the WP_CONTENT_DIR.